### PR TITLE
Adding LinkTo helper methods

### DIFF
--- a/lib/nanoc/linking/helper.rb
+++ b/lib/nanoc/linking/helper.rb
@@ -75,6 +75,18 @@ module Nanoc::Linking
       @item_rep && @item_rep.path == path
     end
 
+    # Returns whether or not a target is parent of current.
+    #
+    # @param [String, Nanoc::Item, Nanoc::ItemRep] target The path/URL,
+    #   item or item representation that should be evaluated
+    def parent_target?(target)
+      # item path
+      path = target.is_a?(String) ? target : target.path
+
+      # Return true if active, false otherwise
+      @item_rep && @item_rep.path.include?(path)
+    end
+
     # Creates a HTML link using {#link_to}, except when the linked item is
     # the current one. In this case, a span element with class “active” and
     # with the given text will be returned. The HTML-escaping rules for

--- a/lib/nanoc/linking/helper.rb
+++ b/lib/nanoc/linking/helper.rb
@@ -63,6 +63,18 @@ module Nanoc::Linking
       "<a #{attributes}href=\"#{h path}\">#{text}</a>"
     end
 
+    # Returns whether or not a target is current.
+    #
+    # @param [String, Nanoc::Item, Nanoc::ItemRep] target The path/URL,
+    #   item or item representation that should be evaluated
+    def current_target?(target)
+      # item path
+      path = target.is_a?(String) ? target : target.path
+
+      # Return true if active, false otherwise
+      @item_rep && @item_rep.path == path
+    end
+
     # Creates a HTML link using {#link_to}, except when the linked item is
     # the current one. In this case, a span element with class “active” and
     # with the given text will be returned. The HTML-escaping rules for
@@ -88,10 +100,8 @@ module Nanoc::Linking
     #   link_to_unless_current('This Item', @item)
     #   # => '<span class="active" title="You\'re here.">This Item</span>'
     def link_to_unless_current(text, target, attributes={})
-      # Find path
-      path = target.is_a?(String) ? target : target.path
+      if current_target? target
 
-      if @item_rep && @item_rep.path == path
         # Create message
         "<span class=\"active\" title=\"You're here.\">#{text}</span>"
       else


### PR DESCRIPTION
When customising LinkTo it is often handy to check:
- if a target is the one currently processed: current_target?(target)
- if a target is parent of the one currently processed: parent_target?(target)

This pull request add those two methods.

**link_to_unless_current(...)** method was updated to use _current_target?(target)_
